### PR TITLE
 Point accepts up to three positions as per GeoJSON RFC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
 npm-debug.log
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -104,6 +104,25 @@ GeoJSON.parse(singleobject, {Point: ['lat', 'lng']});
   }      
 ```
 
+
+For the Point geometry type, up to three positions may be used (e.g., ['lat', 'lng', 'alt']). The third position can mean anything but typically refers to altitude or elevation):
+
+```javascript
+var singleobject = { name: 'Location A', category: 'Store', street: 'Market', lat: 39.984, lng: -75.343, alt: 1024.76 }
+
+GeoJSON.parse(singleobject, {Point: ['lat', 'lng', 'alt']});
+
+  {
+    "type": "Feature",
+    "geometry": {"type": "Point", "coordinates": [-75.343, 39.984, 1024.76]},
+    "properties": {
+      "name": "Location A",
+      "category": "Store"
+    }
+  }      
+```
+
+
 The `parse` method can handle data with different geometry types. Consider the following sample data:
 
 ```javascript

--- a/geojson.js
+++ b/geojson.js
@@ -211,10 +211,34 @@
         }));
       }
 
+      // Geometry parameter specified as: {Point: ['lat', 'lng', 'alt']}
+      else if(Array.isArray(val) && item.hasOwnProperty(val[0]) && item.hasOwnProperty(val[1]) && item.hasOwnProperty(val[2])){
+        geom.type = gtype;
+        geom.coordinates = [Number(item[val[1]]), Number(item[val[0]]),  Number(item[val[2]])];
+      }
+
       // Geometry parameter specified as: {Point: ['lat', 'lng']}
       else if(Array.isArray(val) && item.hasOwnProperty(val[0]) && item.hasOwnProperty(val[1])){
         geom.type = gtype;
         geom.coordinates = [Number(item[val[1]]), Number(item[val[0]])];
+      }
+
+      // Geometry parameter specified as: {Point: ['container.lat', 'container.lng', 'container.alt']}
+      else if(Array.isArray(val) && isNested(val[0]) && isNested(val[1]) && isNested(val[2])){
+        var coordinates = [];
+        for (var i = 0; i < val.length; i++) {	// i.e. 0 and 1
+          var paths = val[i].split('.');
+          var itemClone = item;
+          for (var j = 0; j < paths.length; j++) {
+            if (!itemClone.hasOwnProperty(paths[j])) {
+              return false;
+            }
+            itemClone = itemClone[paths[j]];	// Iterate deeper into the object
+          }
+          coordinates[i] = itemClone;
+        }
+        geom.type = gtype;
+        geom.coordinates = [Number(coordinates[1]), Number(coordinates[0]), Number(coordinates[2])];
       }
 
       // Geometry parameter specified as: {Point: ['container.lat', 'container.lng']}

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "type": "git",
     "url": "http://github.com/caseycesari/geojson.js.git"
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "mocha": "*",
     "expect.js": "*",

--- a/test/test.js
+++ b/test/test.js
@@ -466,5 +466,39 @@ describe('GeoJSON', function() {
       expect(output.geometry.coordinates[0]).to.be.eql([-82.38140709999999, 29.8399961]);
       expect(output.geometry.coordinates[1]).to.be.eql([-82.555449, 29.7183041]);
     });
+
+    it('can accept up to three arguments for Point', function(done) {
+      var data = [
+        { name: 'Location A', category: 'Store', lat: 39.984, lng: -75.343, alt: 22026.46, street: 'Market' },
+        // { name: 'Location B', category: 'House', lat: 39.284, lng: -75.833, alt: 8103.08, street: 'Broad' },
+        // { name: 'Location C', category: 'Office', lat: 39.123, lng: -74.534, alt: 2980.95, street: 'South' }
+      ];
+
+      GeoJSON.parse(data, { Point: ['lat', 'lng', 'alt'] }, function(geojson) {
+        expect(geojson.type).to.be('FeatureCollection');
+        expect(geojson.features).to.be.an('array');
+        expect(geojson.features.length).to.be(1);
+        expect(geojson.features[0].geometry.coordinates[0]).to.equal(-75.343);
+        expect(geojson.features[0].geometry.coordinates[1]).to.equal(39.984);
+        expect(geojson.features[0].geometry.coordinates[2]).to.equal(22026.46);
+        done();
+      });
+    });
+
+    it('can accept up to three arguments for Point in a nested structure', function(done) {
+      var data = [
+        { name: 'Location A', category: 'Store', location: { lat: 39.984, lng: -75.343, alt: 22026.46 }, street: 'Market' },
+      ];
+
+      GeoJSON.parse(data, { Point: ['location.lat', 'location.lng', 'location.alt'] }, function(geojson) {
+        expect(geojson.type).to.be('FeatureCollection');
+        expect(geojson.features).to.be.an('array');
+        expect(geojson.features.length).to.be(1);
+        expect(geojson.features[0].geometry.coordinates[0]).to.equal(-75.343);
+        expect(geojson.features[0].geometry.coordinates[1]).to.equal(39.984);
+        expect(geojson.features[0].geometry.coordinates[2]).to.equal(22026.46);
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
See issue #31 

Parse method accepts both: `{Point: ['lat', 'lng', 'alt']}` or `{Point: ['container.lat', 'container.lng', 'container.alt']}`.